### PR TITLE
Fixing incorrect work with validations

### DIFF
--- a/lib/ohm/expire.rb
+++ b/lib/ohm/expire.rb
@@ -49,9 +49,10 @@ module Ohm
             #
             # * self
             def create(*args)
+                args = [{}] if args.empty?
                 args.first.merge!(:_default_expire => @expire)
                 object = super(*args)
-                if !object.new? && @expire
+                if object && !object.new? && @expire
                     Ohm.redis.expire(object.key, @expire)
                     Ohm.redis.expire("#{object.key}:_indices", @expire)
                 end

--- a/test/expire-test.rb
+++ b/test/expire-test.rb
@@ -8,17 +8,22 @@ class Model < Ohm::Model
     TTL = 5
 
     attribute :hash
+    attribute :required_attr
     index :hash
 
     expire TTL
 
     attribute :data
+
+    def validate
+        assert_present :required_attr
+    end
 end
 
 test do
     Ohm.flush
 
-    m = Model.create(:hash => "123")
+    m = Model.create(:hash => "123", :required_attr => "1")
     assert_equal Model::TTL, m.get_ttl
 
     m.update_ttl 3
@@ -37,4 +42,12 @@ test do
 
     m = Model.find(:hash => "123").first
     assert m.hash.nil?
+
+    # invalid model should not raise undefined method for nil:NilClass
+    invalid_model = Model.create(:hash => "123")
+    assert invalid_model.nil?
+
+    # invalid model should not raise undefined method for nil:NilClass
+    empty_model = Model.create
+    assert invalid_model.nil?
 end


### PR DESCRIPTION
Executing 

``` ruby
  Model.create(params)
  #or
  Model.create
```

fails with "undefined method for nil:NilClass" exception, if validation is not passed
but should return nil (afaik)
